### PR TITLE
Add support for Page's Icon retrieval and updates

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1803,11 +1803,10 @@ func TestUpdatePageProps(t *testing.T) {
 		{
 			name: "page icon, successful response",
 			params: notion.UpdatePageParams{
-				Title: []notion.RichText{
-					{
-						Text: &notion.Text{
-							Content: "Foobar",
-						},
+				Icon: &notion.Icon{
+					Type: notion.IconTypeExternal,
+					External: &notion.IconExternal{
+						URL: "https://www.notion.so/front-static/pages/pricing/pro.png",
 					},
 				},
 			},
@@ -1821,6 +1820,12 @@ func TestUpdatePageProps(t *testing.T) {
 						"parent": {
 							"type": "page_id",
 							"page_id": "b0668f48-8d66-4733-9bdb-2f82215707f7"
+						},
+						"icon": {
+							"type": "external",
+							"external": {
+								"url": "https://www.notion.so/front-static/pages/pricing/pro.png"
+							}
 						},
 						"archived": false,
 						"url": "https://www.notion.so/Avocado-251d2b5f268c4de2afe9c71ff92ca95c",
@@ -1871,9 +1876,25 @@ func TestUpdatePageProps(t *testing.T) {
 					PageID: "b0668f48-8d66-4733-9bdb-2f82215707f7",
 				},
 				Icon: &notion.Icon{
-					Type: "external",
+					Type: notion.IconTypeExternal,
 					External: &notion.IconExternal{
-						Url: "https://www.notion.so/front-static/pages/pricing/pro.png",
+						URL: "https://www.notion.so/front-static/pages/pricing/pro.png",
+					},
+				},
+				Properties: notion.PageProperties{
+					Title: notion.PageTitle{
+						Title: []notion.RichText{
+							{
+								Type: notion.RichTextTypeText,
+								Text: &notion.Text{
+									Content: "Lorem ipsum",
+								},
+								Annotations: &notion.Annotations{
+									Color: notion.ColorDefault,
+								},
+								PlainText: "Lorem ipsum",
+							},
+						},
 					},
 				},
 			},
@@ -2014,10 +2035,10 @@ func TestUpdatePageProps(t *testing.T) {
 			expError:    errors.New("notion: failed to update page properties: foobar (code: validation_error, status: 400)"),
 		},
 		{
-			name:        "missing page title and database properties",
+			name:        "missing any params",
 			params:      notion.UpdatePageParams{},
 			expResponse: notion.Page{},
-			expError:    errors.New("notion: invalid page params: either database page properties or title is required"),
+			expError:    errors.New("notion: invalid page params: at least one of database page properties, title or icon is required"),
 		},
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -935,6 +935,10 @@ func TestCreateDatabase(t *testing.T) {
 						Title: &notion.EmptyMetadata{},
 					},
 				},
+				Icon: &notion.Icon{
+					Type:  notion.IconTypeEmoji,
+					Emoji: notion.StringPtr("✌️"),
+				},
 			},
 			respBody: func(_ *http.Request) io.Reader {
 				return strings.NewReader(
@@ -972,6 +976,10 @@ func TestCreateDatabase(t *testing.T) {
 						"parent": {
 							"type": "page_id",
 							"page_id": "b0668f48-8d66-4733-9bdb-2f82215707f7"
+						},
+						"icon": {
+							"type": "emoji",
+							"emoji": "✌️"
 						}
 					}`,
 				)
@@ -994,6 +1002,10 @@ func TestCreateDatabase(t *testing.T) {
 						"type":  "title",
 						"title": map[string]interface{}{},
 					},
+				},
+				"icon": map[string]interface{}{
+					"type":  "emoji",
+					"emoji": "✌️",
 				},
 			},
 			expResponse: notion.Database{
@@ -1022,6 +1034,10 @@ func TestCreateDatabase(t *testing.T) {
 						Type:  notion.DBPropTypeTitle,
 						Title: &notion.EmptyMetadata{},
 					},
+				},
+				Icon: notion.Icon{
+					Type:  notion.IconTypeEmoji,
+					Emoji: notion.StringPtr("✌️"),
 				},
 			},
 			expError: nil,

--- a/client_test.go
+++ b/client_test.go
@@ -1801,6 +1801,85 @@ func TestUpdatePageProps(t *testing.T) {
 			expError: nil,
 		},
 		{
+			name: "page icon, successful response",
+			params: notion.UpdatePageParams{
+				Title: []notion.RichText{
+					{
+						Text: &notion.Text{
+							Content: "Foobar",
+						},
+					},
+				},
+			},
+			respBody: func(_ *http.Request) io.Reader {
+				return strings.NewReader(
+					`{
+						"object": "page",
+						"id": "cb261dc5-6c85-4767-8585-3852382fb466",
+						"created_time": "2021-05-14T09:15:46.796Z",
+						"last_edited_time": "2021-05-22T15:54:31.116Z",
+						"parent": {
+							"type": "page_id",
+							"page_id": "b0668f48-8d66-4733-9bdb-2f82215707f7"
+						},
+						"archived": false,
+						"url": "https://www.notion.so/Avocado-251d2b5f268c4de2afe9c71ff92ca95c",
+						"properties": {
+							"title": {
+								"id": "title",
+								"type": "title",
+								"title": [
+									{
+										"type": "text",
+										"text": {
+											"content": "Lorem ipsum",
+											"link": null
+										},
+										"annotations": {
+											"bold": false,
+											"italic": false,
+											"strikethrough": false,
+											"underline": false,
+											"code": false,
+											"color": "default"
+										},
+										"plain_text": "Lorem ipsum",
+										"href": null
+									}
+								]
+							}
+						}
+					}`,
+				)
+			},
+			respStatusCode: http.StatusOK,
+			expPostBody: map[string]interface{}{
+				"icon": map[string]interface{}{
+					"type": "external",
+					"external": map[string]interface{}{
+						"url": "https://www.notion.so/front-static/pages/pricing/pro.png",
+					},
+				},
+			},
+			expResponse: notion.Page{
+				ID:             "cb261dc5-6c85-4767-8585-3852382fb466",
+				CreatedTime:    mustParseTime(time.RFC3339Nano, "2021-05-14T09:15:46.796Z"),
+				LastEditedTime: mustParseTime(time.RFC3339Nano, "2021-05-22T15:54:31.116Z"),
+				URL:            "https://www.notion.so/Avocado-251d2b5f268c4de2afe9c71ff92ca95c",
+				Parent: notion.Parent{
+					Type:   notion.ParentTypePage,
+					PageID: "b0668f48-8d66-4733-9bdb-2f82215707f7",
+				},
+				Icon: &notion.Icon{
+					Type: "external",
+					External: &notion.IconExternal{
+						Url: "https://www.notion.so/front-static/pages/pricing/pro.png",
+					},
+				},
+			},
+			expError: nil,
+		},
+		{
 			name: "database page props, successful response",
 			params: notion.UpdatePageParams{
 				DatabasePageProperties: &notion.DatabasePageProperties{

--- a/database.go
+++ b/database.go
@@ -15,6 +15,7 @@ type Database struct {
 	Title          []RichText         `json:"title"`
 	Properties     DatabaseProperties `json:"properties"`
 	Parent         Parent             `json:"parent"`
+	Icon           Icon               `json:"icon"`
 }
 
 // DatabaseProperties is a mapping of properties defined on a database.
@@ -235,6 +236,7 @@ type CreateDatabaseParams struct {
 	ParentPageID string
 	Title        []RichText
 	Properties   DatabaseProperties
+	Icon         *Icon
 }
 
 type (
@@ -362,6 +364,11 @@ func (p CreateDatabaseParams) Validate() error {
 	if p.Properties == nil {
 		return errors.New("database properties are required")
 	}
+	if p.Icon != nil {
+		if err := p.Icon.Validate(); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -372,6 +379,7 @@ func (p CreateDatabaseParams) MarshalJSON() ([]byte, error) {
 		Parent     Parent             `json:"parent"`
 		Title      []RichText         `json:"title,omitempty"`
 		Properties DatabaseProperties `json:"properties"`
+		Icon       *Icon              `json:"icon,omitempty"`
 	}
 
 	parent := Parent{
@@ -383,6 +391,7 @@ func (p CreateDatabaseParams) MarshalJSON() ([]byte, error) {
 		Parent:     parent,
 		Title:      p.Title,
 		Properties: p.Properties,
+		Icon:       p.Icon,
 	}
 
 	return json.Marshal(dto)

--- a/icon.go
+++ b/icon.go
@@ -1,0 +1,48 @@
+package notion
+
+import "errors"
+
+type IconType string
+
+const (
+	IconTypeEmoji    IconType = "emoji"
+	IconTypeFile     IconType = "file"
+	IconTypeExternal IconType = "external"
+)
+
+// Icon has one non-nil Emoji, File or External field, denoted by the
+// corresponding IconType.
+type Icon struct {
+	Type IconType `json:"type"`
+
+	Emoji    *string       `json:"emoji,omitempty"`
+	File     *IconFile     `json:"file,omitempty"`
+	External *IconExternal `json:"external,omitempty"`
+}
+
+type IconFile struct {
+	URL        string `json:"url"`
+	ExpiryTime string `json:"expiry_time"`
+}
+
+type IconExternal struct {
+	URL string `json:"url"`
+}
+
+func (icon Icon) Validate() error {
+	if icon.Type == "" {
+		return errors.New("icon type cannot be empty")
+	}
+
+	if icon.Type == IconTypeEmoji && icon.Emoji == nil {
+		return errors.New("icon emoji cannot be empty")
+	}
+	if icon.Type == IconTypeFile && icon.File == nil {
+		return errors.New("icon file cannot be empty")
+	}
+	if icon.Type == IconTypeExternal && icon.External == nil {
+		return errors.New("icon external cannot be empty")
+	}
+
+	return nil
+}

--- a/icon.go
+++ b/icon.go
@@ -6,23 +6,16 @@ type IconType string
 
 const (
 	IconTypeEmoji    IconType = "emoji"
-	IconTypeFile     IconType = "file"
 	IconTypeExternal IconType = "external"
 )
 
-// Icon has one non-nil Emoji, File or External field, denoted by the
-// corresponding IconType.
+// Icon has one non-nil Emoji or External field, denoted by the corresponding
+// IconType.
 type Icon struct {
 	Type IconType `json:"type"`
 
 	Emoji    *string       `json:"emoji,omitempty"`
-	File     *IconFile     `json:"file,omitempty"`
 	External *IconExternal `json:"external,omitempty"`
-}
-
-type IconFile struct {
-	URL        string `json:"url"`
-	ExpiryTime string `json:"expiry_time"`
 }
 
 type IconExternal struct {
@@ -36,9 +29,6 @@ func (icon Icon) Validate() error {
 
 	if icon.Type == IconTypeEmoji && icon.Emoji == nil {
 		return errors.New("icon emoji cannot be empty")
-	}
-	if icon.Type == IconTypeFile && icon.File == nil {
-		return errors.New("icon file cannot be empty")
 	}
 	if icon.Type == IconTypeExternal && icon.External == nil {
 		return errors.New("icon external cannot be empty")

--- a/page.go
+++ b/page.go
@@ -97,6 +97,8 @@ type CreatePageParams struct {
 
 	// Optionally, children blocks are added to the page.
 	Children []Block
+
+	Icon *Icon
 }
 
 type UpdatePageParams struct {
@@ -175,6 +177,7 @@ func (p CreatePageParams) MarshalJSON() ([]byte, error) {
 		Parent     Parent      `json:"parent"`
 		Properties interface{} `json:"properties"`
 		Children   []Block     `json:"children,omitempty"`
+		Icon       *Icon       `json:"icon,omitempty"`
 	}
 
 	var parent Parent
@@ -188,6 +191,7 @@ func (p CreatePageParams) MarshalJSON() ([]byte, error) {
 	dto := CreatePageParamsDTO{
 		Parent:   parent,
 		Children: p.Children,
+		Icon:     p.Icon,
 	}
 
 	if p.DatabasePageProperties != nil {


### PR DESCRIPTION
Hi,

Thanks for having built this sdk ! 
It has been very useful

Notion have added Page's icon to their API
https://developers.notion.com/changelog/page-icons-cover-images-new-block-types-and-improved-page-file-properties

This commits add the ability to retrieve these icons and to set/update them

Have a good day