### PR TITLE
add block parent

### DIFF
--- a/page.go
+++ b/page.go
@@ -278,6 +278,8 @@ func (p *Page) UnmarshalJSON(b []byte) error {
 	switch dto.Parent.Type {
 	case "workspace":
 		fallthrough
+	case "block_id":
+		fallthrough
 	case "page_id":
 		var props PageProperties
 		err := json.Unmarshal(dto.Properties, &props)

--- a/page.go
+++ b/page.go
@@ -276,18 +276,18 @@ func (p *Page) UnmarshalJSON(b []byte) error {
 	page := dto.PageAlias
 
 	switch dto.Parent.Type {
-	case "workspace":
+	case ParentTypeWorkspace:
 		fallthrough
-	case "block_id":
+	case ParentTypeBlock:
 		fallthrough
-	case "page_id":
+	case ParentTypePage:
 		var props PageProperties
 		err := json.Unmarshal(dto.Properties, &props)
 		if err != nil {
 			return err
 		}
 		page.Properties = props
-	case "database_id":
+	case ParentTypeDatabase:
 		var props DatabasePageProperties
 		err := json.Unmarshal(dto.Properties, &props)
 		if err != nil {


### PR DESCRIPTION
A parent object can be a block, with the same properties as a page parent.
https://developers.notion.com/reference/parent-object