### PR TITLE
don't panic when unmarshaling blocks

### DIFF
--- a/client.go
+++ b/client.go
@@ -437,7 +437,7 @@ func (c *Client) FindBlockByID(ctx context.Context, blockID string) (Block, erro
 		return nil, fmt.Errorf("notion: failed to parse HTTP response: %w", err)
 	}
 
-	return dto.Block(), nil
+	return dto.Block()
 }
 
 // UpdateBlock updates a block.
@@ -472,10 +472,11 @@ func (c *Client) UpdateBlock(ctx context.Context, blockID string, block Block) (
 		return nil, fmt.Errorf("notion: failed to parse HTTP response: %w", err)
 	}
 
-	return dto.Block(), nil
+	return dto.Block()
 }
 
 // DeleteBlock sets `archived: true` on a (page) block object.
+// Will return UnsupportedBlockError if it deletes the block but cannot decode it
 // See: https://developers.notion.com/reference/delete-a-block
 func (c *Client) DeleteBlock(ctx context.Context, blockID string) (Block, error) {
 	req, err := c.newRequest(ctx, http.MethodDelete, "/blocks/"+blockID, nil)
@@ -500,7 +501,7 @@ func (c *Client) DeleteBlock(ctx context.Context, blockID string) (Block, error)
 		return nil, fmt.Errorf("notion: failed to parse HTTP response: %w", err)
 	}
 
-	return dto.Block(), nil
+	return dto.Block()
 }
 
 // FindUserByID fetches a user by ID.

--- a/error.go
+++ b/error.go
@@ -67,6 +67,3 @@ func parseErrorResponse(res *http.Response) error {
 
 	return &apiErr
 }
-
-// UnsupportedBlockError is an internal failure when a block is unknown and cannot be decoded
-var UnsupportedBlockError = errors.New("unsupported block type")

--- a/error.go
+++ b/error.go
@@ -67,3 +67,6 @@ func parseErrorResponse(res *http.Response) error {
 
 	return &apiErr
 }
+
+// UnsupportedBlockError is an internal failure when a block is unknown and cannot be decoded
+var UnsupportedBlockError = errors.New("unsupported block type")


### PR DESCRIPTION
This library shouldn't panic when it encounters an unsupported block type.  Just omit that block from the returned blocks.