### PR TITLE
handle unknown errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -62,7 +62,7 @@ func parseErrorResponse(res *http.Response) error {
 
 	err := json.NewDecoder(res.Body).Decode(&apiErr)
 	if err != nil {
-		return fmt.Errorf("failed to parse error from HTTP response: %w", err)
+		return &APIError{Status: res.StatusCode}
 	}
 
 	return &apiErr


### PR DESCRIPTION
Notion doesn't always return an error object.  In those cases, let's at least inform the caller with the StatusCode.

I see this in the logs.  It appears Notion is replying with html instead of json.
`failed to search: failed to parse error from HTTP response: invalid character '<' looking for beginning of value`

The json parsing error isn't very helpful, so just populate the StatusCode instead.